### PR TITLE
Fix upgrading from iroha version 9

### DIFF
--- a/versions/pre-rc-11/Cargo.lock
+++ b/versions/pre-rc-11/Cargo.lock
@@ -1759,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "iroha_crypto"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "getset",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "iroha_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "iroha_ffi"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_ffi_derive 2.0.0-pre-rc.9",
 ]
@@ -1902,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "iroha_ffi_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "proc-macro-error",
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_derive 2.0.0-pre-rc.9",
 ]
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "fixnum 0.8.0",
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "fixnum 0.8.0",
  "iroha_schema_derive 2.0.0-pre-rc.9",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "iroha_version"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_macro 2.0.0-pre-rc.9",
  "iroha_schema 2.0.0-pre-rc.9",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "iroha_version_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/versions/pre-rc-11/Cargo.toml
+++ b/versions/pre-rc-11/Cargo.toml
@@ -17,15 +17,15 @@ panic = "abort"
 iroha_config = { git = "https://github.com/hyperledger/iroha.git", rev = "a4d5c9f8ddb1ea51f75569b04eb78525d4cf02f2" }
 iroha_core = { git = "https://github.com/hyperledger/iroha.git", rev = "a4d5c9f8ddb1ea51f75569b04eb78525d4cf02f2" }
 iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "a4d5c9f8ddb1ea51f75569b04eb78525d4cf02f2", features = ["mutable_api"] }
-from_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.9", package = "iroha_data_model", features = ["mutable_api"] }
+from_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1", package = "iroha_data_model", features = ["mutable_api"] }
 iroha_logger = { git = "https://github.com/hyperledger/iroha.git", rev = "a4d5c9f8ddb1ea51f75569b04eb78525d4cf02f2" }
 iroha-squash-macros = { path = "../../macro" }
 iroha_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "a4d5c9f8ddb1ea51f75569b04eb78525d4cf02f2" }
-from_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.9", package = "iroha_schema" }
+from_schema = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1", package = "iroha_schema" }
 iroha_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "a4d5c9f8ddb1ea51f75569b04eb78525d4cf02f2" }
-from_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.9", package = "iroha_primitives" }
+from_primitives = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1", package = "iroha_primitives" }
 iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "a4d5c9f8ddb1ea51f75569b04eb78525d4cf02f2" }
-from_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.9", package = "iroha_crypto" }
+from_crypto = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1", package = "iroha_crypto" }
 parity-scale-codec = "3"
 libc = "0.2.139"
 rayon = "*"

--- a/versions/pre-rc-13/Cargo.lock
+++ b/versions/pre-rc-13/Cargo.lock
@@ -1766,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "iroha_crypto"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "getset",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -1850,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "iroha_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "iroha_ffi"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_ffi_derive 2.0.0-pre-rc.9",
 ]
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "iroha_ffi_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "proc-macro-error",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_derive 2.0.0-pre-rc.9",
 ]
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "fixnum 0.8.0",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "fixnum 0.8.0",
  "iroha_schema_derive 2.0.0-pre-rc.9",
@@ -2080,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "iroha_version"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_macro 2.0.0-pre-rc.9",
  "iroha_schema 2.0.0-pre-rc.9",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "iroha_version_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.9#b783f10fa7de26ed1fdd4c526bd162f8636f1a65"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/versions/pre-rc-13/Cargo.toml
+++ b/versions/pre-rc-13/Cargo.toml
@@ -15,15 +15,15 @@ panic = "abort"
 iroha_config = { git = "https://github.com/hyperledger/iroha.git", rev = "c4af68c4f7959b154eb5380aa93c894e2e63fe4e" }
 iroha_core = { git = "https://github.com/hyperledger/iroha.git", rev = "c4af68c4f7959b154eb5380aa93c894e2e63fe4e" }
 iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "c4af68c4f7959b154eb5380aa93c894e2e63fe4e", features = ["mutable_api"] }
-from_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.9", package = "iroha_data_model", features = ["mutable_api"] }
+from_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1", package = "iroha_data_model", features = ["mutable_api"] }
 iroha_logger = { git = "https://github.com/hyperledger/iroha.git", rev = "c4af68c4f7959b154eb5380aa93c894e2e63fe4e" }
 iroha-squash-macros = { path = "../../macro" }
 iroha_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "c4af68c4f7959b154eb5380aa93c894e2e63fe4e" }
-from_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.9", package = "iroha_schema" }
+from_schema = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1", package = "iroha_schema" }
 iroha_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "c4af68c4f7959b154eb5380aa93c894e2e63fe4e" }
-from_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.9", package = "iroha_primitives" }
+from_primitives = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1", package = "iroha_primitives" }
 iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "c4af68c4f7959b154eb5380aa93c894e2e63fe4e" }
-from_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.9", package = "iroha_crypto" }
+from_crypto = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1", package = "iroha_crypto" }
 parity-scale-codec = "3"
 libc = "0.2.139"
 rayon = "*"


### PR DESCRIPTION
Closes https://github.com/hyperledger/iroha/issues/4551

I created new branch [`v2.0.0-pre-rc.9.1`](https://github.com/hyperledger/iroha/commits/v2.0.0-pre-rc.9.1/) with fix in [`iroha`](https://github.com/hyperledger/iroha) repository. This PR changed to use that branch.