### PR TITLE
Fix upgrading to versions 19 and 20

### DIFF
--- a/versions/pre-rc-19/src/lib.rs
+++ b/versions/pre-rc-19/src/lib.rs
@@ -419,6 +419,7 @@ pub extern "C" fn upgrade(from: *const libc::c_char) -> *mut libc::c_char {
         .into_owned();
 
     #[derive(Deserialize)]
+    #[serde(transparent)]
     struct Transaction {
         isi: Vec<from_data_model::isi::InstructionBox>,
     }

--- a/versions/pre-rc-19/src/upgrade.rs
+++ b/versions/pre-rc-19/src/upgrade.rs
@@ -537,7 +537,6 @@ impl_upgrade! {
 unobtainable!(account::Account);
 unobtainable!(asset::AssetDefinition);
 unobtainable!(asset::Asset);
-unobtainable!(role::Role);
 unobtainable!(domain::Domain);
 
 fn contract_hash(
@@ -580,6 +579,11 @@ forward_upgrade! {
 forward_upgrade! {
     struct role::NewRole;
     inner
+}
+
+forward_upgrade! {
+    struct role::Role;
+    id, permissions
 }
 
 forward_upgrade! {

--- a/versions/pre-rc-20/src/lib.rs
+++ b/versions/pre-rc-20/src/lib.rs
@@ -34,6 +34,7 @@ pub extern "C" fn upgrade(from: *const libc::c_char) -> *mut libc::c_char {
         .into_owned();
 
     #[derive(Deserialize)]
+    #[serde(transparent)]
     struct Transaction {
         isi: Vec<from_data_model::isi::InstructionBox>,
     }

--- a/versions/pre-rc-20/src/upgrade.rs
+++ b/versions/pre-rc-20/src/upgrade.rs
@@ -743,7 +743,6 @@ impl_upgrade! {
 unobtainable!(account::Account);
 unobtainable!(asset::AssetDefinition);
 unobtainable!(asset::Asset);
-unobtainable!(role::Role);
 unobtainable!(domain::Domain);
 
 fn contract_hash(
@@ -786,6 +785,11 @@ forward_upgrade! {
 forward_upgrade! {
     struct role::NewRole;
     inner
+}
+
+forward_upgrade! {
+    struct role::Role;
+    id, permissions
 }
 
 forward_upgrade! {


### PR DESCRIPTION
* Starting from iroha v16, [`GenesisTransaction` has `#[serde(transparent)]`](https://github.com/hyperledger/iroha/blob/e467e1a24124ce47546f52e4ac807b2d55bb6a4d/genesis/src/lib.rs#L228), so need to add it when converting rc16 → rc19 and rc19 → rc20
* Implemented upgrade for `role::Role`