### PR TITLE
Fix permission token upgrade from rc19 to rc20

### DIFF
--- a/versions/pre-rc-19/Cargo.lock
+++ b/versions/pre-rc-19/Cargo.lock
@@ -2171,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "iroha_config"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_base"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "crossbeam",
  "displaydoc",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "iroha_macro_utils 2.0.0-pre-rc.18",
  "proc-macro-error",
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "iroha_core"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -2260,7 +2260,7 @@ dependencies = [
 [[package]]
 name = "iroha_core_wasm_codec_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "once_cell",
  "proc-macro-error",
@@ -2289,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "iroha_crypto"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "derive_more",
  "getset",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "iroha_macro_utils 2.0.0-pre-rc.18",
  "proc-macro-error",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "iroha_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "darling",
  "manyhow",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "iroha_genesis"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "derive_more",
  "eyre",
@@ -2449,7 +2449,7 @@ dependencies = [
 [[package]]
 name = "iroha_logger"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "color-eyre",
  "derive_more",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "iroha_derive 2.0.0-pre-rc.18",
 ]
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro_utils"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2506,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "iroha_p2p"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "aead",
  "async-stream",
@@ -2547,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "manyhow",
  "proc-macro2",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "fixnum",
  "iroha_schema_derive 2.0.0-pre-rc.18",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2617,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "iroha_version"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "iroha_macro 2.0.0-pre-rc.18",
  "iroha_version_derive 2.0.0-pre-rc.18",
@@ -2690,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "iroha_version_derive"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "darling",
  "manyhow",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "iroha_wasm_codec"
 version = "2.0.0-pre-rc.18"
-source = "git+https://github.com/hyperledger/iroha.git?rev=7e7c120e0dc4e5c786f0c421fc25205621cff31a#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "iroha_core_wasm_codec_derive",
  "parity-scale-codec",

--- a/versions/pre-rc-19/Cargo.toml
+++ b/versions/pre-rc-19/Cargo.toml
@@ -12,15 +12,15 @@ panic = "abort"
 [workspace]
 
 [dependencies]
-iroha_config = { git = "https://github.com/hyperledger/iroha.git", rev = "7e7c120e0dc4e5c786f0c421fc25205621cff31a" }
-iroha_core = { git = "https://github.com/hyperledger/iroha.git", rev = "7e7c120e0dc4e5c786f0c421fc25205621cff31a" }
-iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "7e7c120e0dc4e5c786f0c421fc25205621cff31a" }
-iroha_logger = { git = "https://github.com/hyperledger/iroha.git", rev = "7e7c120e0dc4e5c786f0c421fc25205621cff31a" }
+iroha_config = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19" }
+iroha_core = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19" }
+iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19" }
+iroha_logger = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19" }
 iroha-squash-macros = { path = "../../macro" }
-iroha_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "7e7c120e0dc4e5c786f0c421fc25205621cff31a" }
-iroha_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "7e7c120e0dc4e5c786f0c421fc25205621cff31a" }
-iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "7e7c120e0dc4e5c786f0c421fc25205621cff31a" }
-iroha_genesis = { git = "https://github.com/hyperledger/iroha.git", rev = "7e7c120e0dc4e5c786f0c421fc25205621cff31a" }
+iroha_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19" }
+iroha_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19" }
+iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19" }
+iroha_genesis = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19" }
 
 from_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "e467e1a24124ce47546f52e4ac807b2d55bb6a4d", package = "iroha_data_model", features = ["transparent_api"] }
 from_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "e467e1a24124ce47546f52e4ac807b2d55bb6a4d", package = "iroha_crypto" }

--- a/versions/pre-rc-20/Cargo.lock
+++ b/versions/pre-rc-20/Cargo.lock
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "iroha_config"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_base"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "crossbeam",
  "displaydoc",
@@ -2154,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "iroha_macro_utils 2.0.0-pre-rc.20",
  "proc-macro-error",
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "iroha_core"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "async-trait",
  "crossbeam-queue",
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "iroha_core_wasm_codec_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "once_cell",
  "proc-macro-error",
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "iroha_crypto"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "derive_more",
  "getset",
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "base64 0.21.5",
  "derive_more",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "darling",
  "iroha_macro_utils 2.0.0-pre-rc.20",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "iroha_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "darling",
  "manyhow 0.8.1",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "iroha_macro_utils 2.0.0-pre-rc.20",
  "manyhow 0.8.1",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "iroha_genesis"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "derive_more",
  "eyre",
@@ -2390,7 +2390,7 @@ dependencies = [
 [[package]]
 name = "iroha_logger"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "color-eyre",
  "derive_more",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "iroha_derive 2.0.0-pre-rc.20",
 ]
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro_utils"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "darling",
  "drop_bomb",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "iroha_p2p"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "aead",
  "async-trait",
@@ -2493,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2523,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "manyhow 0.8.1",
  "proc-macro2",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "fixnum",
  "iroha_schema_derive 2.0.0-pre-rc.20",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "darling",
  "manyhow 0.8.1",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2600,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "iroha_version"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "iroha_macro 2.0.0-pre-rc.20",
  "iroha_version_derive 2.0.0-pre-rc.20",
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "iroha_version_derive"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "darling",
  "manyhow 0.8.1",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "iroha_wasm_codec"
 version = "2.0.0-pre-rc.20"
-source = "git+https://github.com/hyperledger/iroha.git?rev=f64586b1431c72e72593d7b32d18ed1d76ce099d#f64586b1431c72e72593d7b32d18ed1d76ce099d"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.20#f9f5ede6791a99ec788a05755867e1fcb497a9e2"
 dependencies = [
  "iroha_core_wasm_codec_derive",
  "parity-scale-codec",

--- a/versions/pre-rc-20/Cargo.lock
+++ b/versions/pre-rc-20/Cargo.lock
@@ -2211,15 +2211,15 @@ dependencies = [
 
 [[package]]
 name = "iroha_crypto"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "derive_more",
  "getset",
  "hex",
- "iroha_macro 2.0.0-pre-rc.19",
- "iroha_primitives 2.0.0-pre-rc.19",
- "iroha_schema 2.0.0-pre-rc.19",
+ "iroha_macro 2.0.0-pre-rc.18",
+ "iroha_primitives 2.0.0-pre-rc.18",
+ "iroha_schema 2.0.0-pre-rc.18",
  "parity-scale-codec",
  "serde",
  "serde_with 2.3.3",
@@ -2245,20 +2245,20 @@ dependencies = [
 
 [[package]]
 name = "iroha_data_model"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
  "derive_more",
  "displaydoc",
  "getset",
- "iroha_crypto 2.0.0-pre-rc.19",
- "iroha_data_model_derive 2.0.0-pre-rc.19",
- "iroha_macro 2.0.0-pre-rc.19",
- "iroha_primitives 2.0.0-pre-rc.19",
- "iroha_schema 2.0.0-pre-rc.19",
- "iroha_version 2.0.0-pre-rc.19",
+ "iroha_crypto 2.0.0-pre-rc.18",
+ "iroha_data_model_derive 2.0.0-pre-rc.18",
+ "iroha_macro 2.0.0-pre-rc.18",
+ "iroha_primitives 2.0.0-pre-rc.18",
+ "iroha_schema 2.0.0-pre-rc.18",
+ "iroha_version 2.0.0-pre-rc.18",
  "parity-scale-codec",
  "serde",
  "serde_json",
@@ -2294,10 +2294,10 @@ dependencies = [
 
 [[package]]
 name = "iroha_data_model_derive"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
- "iroha_macro_utils 2.0.0-pre-rc.19",
+ "iroha_macro_utils 2.0.0-pre-rc.18",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2320,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_derive"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "darling",
  "manyhow 0.5.1",
@@ -2409,10 +2409,10 @@ dependencies = [
 
 [[package]]
 name = "iroha_macro"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
- "iroha_derive 2.0.0-pre-rc.19",
+ "iroha_derive 2.0.0-pre-rc.18",
 ]
 
 [[package]]
@@ -2425,8 +2425,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_macro_utils"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2473,15 +2473,15 @@ dependencies = [
 
 [[package]]
 name = "iroha_primitives"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "derive_more",
  "displaydoc",
  "fixnum",
- "iroha_macro 2.0.0-pre-rc.19",
- "iroha_primitives_derive 2.0.0-pre-rc.19",
- "iroha_schema 2.0.0-pre-rc.19",
+ "iroha_macro 2.0.0-pre-rc.18",
+ "iroha_primitives_derive 2.0.0-pre-rc.18",
+ "iroha_schema 2.0.0-pre-rc.18",
  "parity-scale-codec",
  "serde",
  "serde_with 2.3.3",
@@ -2511,8 +2511,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_primitives_derive"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "manyhow 0.5.1",
  "proc-macro2",
@@ -2533,11 +2533,11 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "fixnum",
- "iroha_schema_derive 2.0.0-pre-rc.19",
+ "iroha_schema_derive 2.0.0-pre-rc.18",
  "serde",
 ]
 
@@ -2553,14 +2553,12 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema_derive"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
- "darling",
- "manyhow 0.5.1",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2612,11 +2610,11 @@ dependencies = [
 
 [[package]]
 name = "iroha_version"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
- "iroha_macro 2.0.0-pre-rc.19",
- "iroha_version_derive 2.0.0-pre-rc.19",
+ "iroha_macro 2.0.0-pre-rc.18",
+ "iroha_version_derive 2.0.0-pre-rc.18",
  "parity-scale-codec",
  "serde",
  "serde_json",
@@ -2639,8 +2637,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_version_derive"
-version = "2.0.0-pre-rc.19"
-source = "git+https://github.com/hyperledger/iroha.git?rev=55da4a1b3b20a189bc3f26121c77ea49e7b5db5e#55da4a1b3b20a189bc3f26121c77ea49e7b5db5e"
+version = "2.0.0-pre-rc.18"
+source = "git+https://github.com/hyperledger/iroha.git?rev=v2.0.0-pre-rc.19#7e7c120e0dc4e5c786f0c421fc25205621cff31a"
 dependencies = [
  "darling",
  "manyhow 0.5.1",
@@ -2827,7 +2825,6 @@ dependencies = [
  "manyhow-macros 0.5.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "syn 2.0.39",
 ]
 
@@ -3289,15 +3286,15 @@ dependencies = [
  "iroha-squash-macros",
  "iroha_config",
  "iroha_core",
- "iroha_crypto 2.0.0-pre-rc.19",
+ "iroha_crypto 2.0.0-pre-rc.18",
  "iroha_crypto 2.0.0-pre-rc.20",
- "iroha_data_model 2.0.0-pre-rc.19",
+ "iroha_data_model 2.0.0-pre-rc.18",
  "iroha_data_model 2.0.0-pre-rc.20",
  "iroha_genesis",
  "iroha_logger",
- "iroha_primitives 2.0.0-pre-rc.19",
+ "iroha_primitives 2.0.0-pre-rc.18",
  "iroha_primitives 2.0.0-pre-rc.20",
- "iroha_schema 2.0.0-pre-rc.19",
+ "iroha_schema 2.0.0-pre-rc.18",
  "iroha_schema 2.0.0-pre-rc.20",
  "libc",
  "once_cell",

--- a/versions/pre-rc-20/Cargo.toml
+++ b/versions/pre-rc-20/Cargo.toml
@@ -22,10 +22,10 @@ iroha_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "f6
 iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
 iroha_genesis = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
 
-from_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "55da4a1b3b20a189bc3f26121c77ea49e7b5db5e", package = "iroha_data_model", features = ["transparent_api"] }
-from_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "55da4a1b3b20a189bc3f26121c77ea49e7b5db5e", package = "iroha_crypto" }
-from_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "55da4a1b3b20a189bc3f26121c77ea49e7b5db5e", package = "iroha_primitives" }
-from_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "55da4a1b3b20a189bc3f26121c77ea49e7b5db5e", package = "iroha_schema" }
+from_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19", package = "iroha_data_model", features = ["transparent_api"] }
+from_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19", package = "iroha_crypto" }
+from_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19", package = "iroha_primitives" }
+from_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19", package = "iroha_schema" }
 
 parity-scale-codec = "3"
 libc = "0.2.139"

--- a/versions/pre-rc-20/Cargo.toml
+++ b/versions/pre-rc-20/Cargo.toml
@@ -12,15 +12,15 @@ panic = "abort"
 [workspace]
 
 [dependencies]
-iroha_config = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
-iroha_core = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
-iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
-iroha_logger = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
+iroha_config = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.20" }
+iroha_core = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.20" }
+iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.20" }
+iroha_logger = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.20" }
 iroha-squash-macros = { path = "../../macro" }
-iroha_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
-iroha_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
-iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
-iroha_genesis = { git = "https://github.com/hyperledger/iroha.git", rev = "f64586b1431c72e72593d7b32d18ed1d76ce099d" }
+iroha_schema = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.20" }
+iroha_primitives = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.20" }
+iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.20" }
+iroha_genesis = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.20" }
 
 from_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19", package = "iroha_data_model", features = ["transparent_api"] }
 from_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "v2.0.0-pre-rc.19", package = "iroha_crypto" }

--- a/versions/pre-rc-9/Cargo.lock
+++ b/versions/pre-rc-9/Cargo.lock
@@ -1632,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "iroha_actor"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "iroha_actor_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1660,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "iroha_config"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "crossbeam",
  "derive_more",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_base"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "crossbeam",
  "iroha_config_derive",
@@ -1692,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "iroha_core"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "iroha_crypto"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "getset",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "iroha_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "iroha_ffi"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_ffi_derive",
 ]
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "iroha_ffi_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "proc-macro-error",
@@ -1821,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -1835,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "iroha_logger"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "color-eyre",
  "derive_more",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_derive",
 ]
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "iroha_p2p"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "aead",
  "async-stream",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "derive_more",
  "fixnum",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "fixnum",
  "iroha_schema_derive",
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1967,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "iroha_version"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "iroha_macro",
  "iroha_schema",
@@ -1982,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "iroha_version_derive"
 version = "2.0.0-pre-rc.9"
-source = "git+https://github.com/hyperledger/iroha.git?rev=9273a912c8a97f9ce1bfaa302c7192554f7abf00#9273a912c8a97f9ce1bfaa302c7192554f7abf00"
+source = "git+https://github.com/hyperledger/iroha.git?branch=v2.0.0-pre-rc.9.1#587bad97732dfc70a3439a023c339f81752530f8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/versions/pre-rc-9/Cargo.toml
+++ b/versions/pre-rc-9/Cargo.toml
@@ -14,11 +14,11 @@ panic = "abort"
 # See more keys and their definitions at httpmacro/doc.rust-lang.omacrocarmacroreferenmacromanifest.html
 
 [dependencies]
-iroha_config = { git = "https://github.com/hyperledger/iroha.git", rev = "9273a912c8a97f9ce1bfaa302c7192554f7abf00" }
-iroha_core = { git = "https://github.com/hyperledger/iroha.git", rev = "9273a912c8a97f9ce1bfaa302c7192554f7abf00" }
-iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", rev = "9273a912c8a97f9ce1bfaa302c7192554f7abf00" }
-iroha_logger = { git = "https://github.com/hyperledger/iroha.git", rev = "9273a912c8a97f9ce1bfaa302c7192554f7abf00" }
-iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "9273a912c8a97f9ce1bfaa302c7192554f7abf00" }
+iroha_config = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1" }
+iroha_core = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1" }
+iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1" }
+iroha_logger = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1" }
+iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", branch = "v2.0.0-pre-rc.9.1" }
 iroha-squash-macros = { path = "../../macro" }
 parity-scale-codec = "3.2.1"
 libc = "0.2.139"


### PR DESCRIPTION
In rc16 and rc20, permission tokens payload is JSON, and in rc19 it is SCALE encoded (array of bytes).

Currently when updating from rc16 to rc20, permission tokens payload becomes array of bytes, however in rc20 it should be JSON. This PR fixes it